### PR TITLE
refactoring selectedVideo relatedVideo

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   height: 56px;
   background: #202020;
+  z-index: 99;
   width: 100%;
 
   a {

--- a/src/components/SideList/SideList.js
+++ b/src/components/SideList/SideList.js
@@ -1,23 +1,11 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import { Store } from "../../store";
 import Style from "./SideList.module.scss";
-import { fetchRelatedData } from "../../apis/index";
 import SideListItem from "../SideListItem/SideListItem";
 
 const SideList = () => {
-  const { globalState, setGlobalState } = useContext(Store);
-  const setRelatedVideo = async (id) => {
-    await fetchRelatedData(id).then((res) => {
-      setGlobalState({
-        type: "SET_RELATED",
-        payload: { related: res.data.items },
-      });
-    });
-  };
-  //動画を選択するごとに関連動画はレンダリング必要なので第二引数に選択した動画（selected）を指定
-  useEffect(() => {
-    setRelatedVideo(globalState.selected.id);
-  }, [globalState.selected]);
+  const { globalState } = useContext(Store);
+
   return (
     <div className={Style.sidenav}>
       {globalState.related.related ? (

--- a/src/components/SideList/SideList.module.scss
+++ b/src/components/SideList/SideList.module.scss
@@ -2,4 +2,8 @@
   width: 480px;
   flex-basis: 480px;
   padding: 1rem;
+  @media screen and (max-width: 960px) {
+    width: 90%;
+    margin: 1rem auto;
+  }
 }

--- a/src/components/SideListItem/SideListItem.module.scss
+++ b/src/components/SideListItem/SideListItem.module.scss
@@ -4,12 +4,19 @@
   margin-bottom: 1rem;
   img {
     width: 50%;
+    @media screen and (max-width: 560px) {
+      width: 100%;
+    }
   }
   .info {
     display: inline-block;
     width: 46%;
     padding: 2%;
     vertical-align: top;
+    @media screen and (max-width: 560px) {
+      width: 100%;
+      padding: 0;
+    }
   }
   span {
     color: white;

--- a/src/components/VideoDetail/VideoDetail.js
+++ b/src/components/VideoDetail/VideoDetail.js
@@ -1,27 +1,12 @@
-import React, { useContext, useEffect } from "react";
-import { useLocation } from "react-router-dom";
-import { fetchSelectedData } from "../../apis";
+import React, { useContext } from "react";
 import { Store } from "../../store/index";
 import VideoPlay from "../VideoPlay/VideoPlay";
 import Style from "./VideoDetail.module.scss";
 import Linkify from "react-linkify";
 
 const VideoDetail = () => {
-  const { globalState, setGlobalState } = useContext(Store);
-  const location = useLocation();
-  const setSelectedVideo = async () => {
-    const searchParams = new URLSearchParams(location.search);
-    const id = searchParams.get("v");
-    await fetchSelectedData(id).then((res) => {
-      //res.data.itemsは配列になっているため、中のオブジェクトを取り出す（中身は1個しかないからshit()でOK）
-      const item = res.data.items.shift();
-      setGlobalState({ type: "SET_SELECTED", payload: { selected: item } });
-    });
-  };
-  //動画の選択時にURLが切り替わるのでレンダリングするように第二引数にURLを設定
-  useEffect(() => {
-    setSelectedVideo();
-  }, [location]);
+  const { globalState } = useContext(Store);
+
   return globalState.selected.selected && globalState.selected.selected.id ? (
     <div className={Style.wrapper}>
       <VideoPlay id={globalState.selected.selected.id} />

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -1,5 +1,4 @@
 .wrapper {
-  height: 100vh;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -10,5 +9,10 @@
     flex: 1;
     width: 100%;
     background: #181818;
+    @media screen and (max-width: 960px) {
+      max-width: 90%;
+      margin: 0 auto;
+      flex-direction: column;
+    }
   }
 }

--- a/src/pages/Top.js
+++ b/src/pages/Top.js
@@ -9,12 +9,12 @@ const Top = () => {
   const { globalState, setGlobalState } = useContext(Store);
 
   useEffect(() => {
-    fetchPopularData().then((res) => {
-      setGlobalState({
-        type: "SET_POPULAR",
-        payload: { popular: res.data.items },
-      });
-    });
+    // fetchPopularData().then((res) => {
+    //   setGlobalState({
+    //     type: "SET_POPULAR",
+    //     payload: { popular: res.data.items },
+    //   });
+    // });
   }, []);
 
   return (

--- a/src/pages/Watch.js
+++ b/src/pages/Watch.js
@@ -1,8 +1,37 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import Layout from "../components/layout/Layout";
 import SideList from "../components/SideList/SideList";
 import VideoDetail from "../components/VideoDetail/VideoDetail";
+import { Store } from "../store/index";
+import { fetchSelectedData, fetchRelatedData } from "../apis/index";
+
 const Watch = () => {
+  const { setGlobalState } = useContext(Store);
+  const location = useLocation();
+  const setVideos = async () => {
+    const searchParams = new URLSearchParams(location.search);
+    const id = searchParams.get("v");
+    if (id) {
+      //Promise.allでfetchSelectedData(動画の詳細表示)とfetchRelatedData(関連動画の表示)の両方が終わるまで待機するようにする。遅延対策。
+      const [selected, related] = await Promise.all([
+        fetchSelectedData(id),
+        fetchRelatedData(id),
+      ]);
+      setGlobalState({
+        type: "SET_SELECTED",
+        //res.data.itemsは配列になっているため、中のオブジェクトを取り出す（中身は1個しかないからshit()でOK）
+        payload: { selected: selected.data.items.shift() },
+      });
+      setGlobalState({
+        type: "SET_RELATED",
+        payload: { related: related.data.items },
+      });
+    }
+  };
+  useEffect(() => {
+    // setVideos();
+  }, [location.search]);
   return (
     <Layout>
       <VideoDetail />


### PR DESCRIPTION
# 動画詳細のリファクタリング
> 選択した動画の詳細表示を`VideoDetail.js`で、関連動画の表示を`SideList.js`で行なっていたため、「動画の表示→関連動画の表示」というレイテンシーが発生していましたので、`Watch.js`にて処理をまとめることにしました。
>> Promise.allを使って「動画詳細の取得」「関連動画の取得」が両方とも終わるまで待つような仕様です。

# スタイルの修正
> レスポンシブでレイエアウト崩れがあったのでスタイルの修正も行なっております。